### PR TITLE
feat,refactor: added bcrypt salting and hashing to passwords, refactored readme.md, signup url endpoint modified

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -7,7 +7,6 @@ The backend of this project is written in Go.
 - Ganesan Santhanam
 
 ## Overview:
----
 
 ### Design Pattern: 
 We will try to adhere to Domain Driven Design (DDD) pattern.
@@ -43,7 +42,6 @@ And that's it! You have setup MongoDB service and restored the database.
 ### Running Server:
 `main.go` file (within backend folder) contains the code that will start the server. The server can be started using these commands: 
 1. `cd backend/`
-2. `go get -u github.com/gin-gonic/gin` 
-3. `go run main.go`.
+2. `go run main.go`.
 
 Now, you can follow the steps to get the frontend up and running and check out the web-app.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.10.0
 	github.com/joho/godotenv v1.4.0
 	go.mongodb.org/mongo-driver v1.8.2
+	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce
 )
 
 require (
@@ -28,7 +29,6 @@ require (
 	github.com/xdg-go/scram v1.1.0 // indirect
 	github.com/xdg-go/stringprep v1.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
-	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
During signup, passwords are now salted and hashed using bcrypt algorithm and a hashing cost of 10 is being used.
Signup url was changed from `/signup` to `/users/signup` in order to make the endpoint more resource-oriented.
Minor cosmetic changes in README.md.