### PR TITLE
fix: checkCommunityExist API response message was correctly set to API_SUCCESS

### DIFF
--- a/backend/communities/service.go
+++ b/backend/communities/service.go
@@ -566,7 +566,7 @@ func CheckCommunityExists() gin.HandlerFunc {
 			http.StatusOK,
 			common.APIResponse{
 				Status:  http.StatusOK,
-				Message: common.API_FAILURE,
+				Message: common.API_SUCCESS,
 				Data:    map[string]interface{}{"communityAlreadyExists": communityAlreadyExists},
 			},
 		)


### PR DESCRIPTION
1.  Changed API response for the checkCommunityExists API > Message: API_FAILURE to Message: API_SUCCESS #115 