### PR TITLE
fix: editCommunity API updates the community after checking if it exists

### DIFF
--- a/backend/communities/service.go
+++ b/backend/communities/service.go
@@ -236,7 +236,7 @@ func EditCommunity() gin.HandlerFunc {
 		}
 
 		communityAlreadyExists, err := checkCommunityNameExists(communityReq.Name)
-		if communityAlreadyExists {
+		if !communityAlreadyExists {
 			c.JSON(
 				http.StatusOK,
 				common.APIResponse{


### PR DESCRIPTION
the EditCommunity API was fixed by negating the boolean value returned by the communityExists function #117 