### PR TITLE
feat: api to delete comments, parent comment validation

### DIFF
--- a/backend/comments/models.go
+++ b/backend/comments/models.go
@@ -1,9 +1,12 @@
 package comments
 
 import (
+	"context"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // Models for Comments
@@ -19,6 +22,7 @@ type CommentDBModel struct {
 	IsVotable bool               `bson:"is_votable"`
 	IsDeleted bool               `bson:"is_deleted"`
 	CreatedAt time.Time          `bson:"created_at"`
+	DeletedAt time.Time          `bson:"deleted_at"`
 }
 
 type CreateCommentRequest struct {
@@ -26,6 +30,10 @@ type CreateCommentRequest struct {
 	UserId   string `json:"user_id" validate:"required"`
 	ParentId string `json:"parent_id" validate:"omitempty"`
 	Body     string `json:"body" validate:"required"`
+}
+
+type DeleteCommentRequest struct {
+	CommentId string `json:"comment_id" uri:"comment_id" validate:"required"`
 }
 
 // Convertion functions to convert between different models.
@@ -56,5 +64,62 @@ func ConvertCommentRequestToCommentDBModel(commentReq CreateCommentRequest) (Com
 		IsVotable: true,
 		IsDeleted: false,
 		CreatedAt: time.Now().UTC(),
+		DeletedAt: time.Time{},
 	}, nil
+}
+
+// Model CRUD functions
+func createCommentInDB(comment CreateCommentRequest) (result *mongo.InsertOneResult, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	newComment, err := ConvertCommentRequestToCommentDBModel(comment) //, err := ConvertCommunityRequestToCommunityDBModel(community)
+	if err != nil {
+		return result, err
+	}
+	result, err = CommentsCollection.InsertOne(ctx, newComment)
+	return result, err
+}
+
+func retrieveCommentById(comment_id_hex string) (CommentDBModel, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var comment CommentDBModel
+	comment_id, err := primitive.ObjectIDFromHex(comment_id_hex)
+	if err != nil {
+		return comment, err
+	}
+	filter := bson.D{primitive.E{Key: "_id", Value: comment_id}}
+	err = CommentsCollection.FindOne(ctx, filter).Decode(&comment)
+	return comment, err
+}
+
+func deleteComment(commReq DeleteCommentRequest) (result *mongo.UpdateResult, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	comment, err := retrieveCommentById(commReq.CommentId)
+	if err != nil {
+		return result, err
+	}
+	// updating the comment in db
+	filter := bson.M{"_id": comment.ID}
+	updateQuery := bson.D{
+		primitive.E{
+			Key: "$set",
+			Value: bson.D{
+				primitive.E{Key: "body", Value: ""},
+				primitive.E{Key: "is_deleted", Value: true},
+				primitive.E{Key: "is_votable", Value: false},
+				primitive.E{Key: "deleted_at", Value: time.Now().UTC()},
+			},
+		},
+	}
+	result, err = CommentsCollection.UpdateOne(
+		ctx,
+		filter,
+		updateQuery,
+	)
+	return result, err
 }

--- a/backend/common/error_msgs.go
+++ b/backend/common/error_msgs.go
@@ -4,3 +4,4 @@ var ERR_COMMUNITY_NOT_FOUND APIMessage = APIMessage{Message: "No record found fo
 var ERR_INCORRECT_CREDENTIALS APIMessage = APIMessage{Message: "Incorrect Credentials"}
 var ERR_USERNAME_ALREADY_EXISTS APIMessage = APIMessage{Message: "Username Already Exists"}
 var ERR_COMMUNITY_ALREADY_EXISTS APIMessage = APIMessage{Message: "Community with that name already exists"}
+var ERR_PARENT_COMMENT_IS_DELETED APIMessage = APIMessage{Message: "Parent comment is deleted"}


### PR DESCRIPTION
Closes #155 

Changes:
- Checks if parent comment id is null or present. If present, parent comment shouldn't be a deleted comment. If parent comment is deleted, prevent creation of child comment.
- API to delete comments. The API doesn't remove child comments, it only marks the comment as deleted and removes the body of the comment.
- Moved DB CRUD related functions into models.go file.